### PR TITLE
Initialize Streamlit multipage dashboard scaffold

### DIFF
--- a/core/page_registry.py
+++ b/core/page_registry.py
@@ -1,0 +1,43 @@
+"""Streamlit ページ定義を管理するモジュール。"""
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass(frozen=True)
+class PageDefinition:
+    """ダッシュボード内で表示するページ情報。"""
+
+    file_name: str
+    title: str
+    description: str
+    status: str = "準備中"
+
+
+
+def get_page_definitions() -> List[PageDefinition]:
+    """トップページで表示するページ一覧を返す。"""
+
+    return [
+        PageDefinition(
+            file_name="00_getting_started.py",
+            title="はじめに",
+            description="このアプリの使い方とページ追加ルールを確認します。",
+            status="利用可能",
+        ),
+        PageDefinition(
+            file_name="10_kpi_dashboard.py",
+            title="KPIダッシュボード",
+            description="主要指標をカード形式で表示するためのページです。",
+        ),
+        PageDefinition(
+            file_name="20_data_explorer.py",
+            title="データ探索",
+            description="テーブル、フィルタ、チャートを配置するページです。",
+        ),
+        PageDefinition(
+            file_name="30_settings.py",
+            title="設定",
+            description="環境変数や設定値を表示・編集するページです。",
+        ),
+    ]

--- a/index.py
+++ b/index.py
@@ -1,61 +1,34 @@
 # -*- coding: utf-8 -*-
 
 import streamlit as st
-from src.st_util import load_csv
 
-import seaborn as sns
-import matplotlib.pyplot as plt
-import pandas as pd
+from core.page_registry import get_page_definitions
 
+st.set_page_config(page_title="Dashboard Index", page_icon="📊", layout="wide")
 
-plt.rcParams["figure.figsize"] = 8, 8
+st.title("📊 Dashboard Index")
+st.caption("Streamlitマルチページ構成のトップページ")
 
-st.set_page_config(layout="wide")
-
-st.title("TOP Page")
-st.write(
+st.markdown(
     """
-    time series plots: \n
-    simulation portfolio: \n
-    machine learning analysis: \n
-    """
+このアプリは、`pages/` 配下に機能単位でページを追加できる構成です。
+
+- **トップページ（この画面）**: 全体インデックス
+- **サブページ**: 1ページ1機能で拡張
+- **共通ロジック**: `core/` に配置
+"""
 )
-# if st.checkbox("Use Sample Data"):
-#     st.header("US Macroeconomic Data from FRED")
-#     st.json({
-#         "realgdp": "Real gross domestic product",
-#         "realcons": "Real personal consumption expenditures",
-#         "realinv" :"Real gross private domestic investment",
-#         "realgovt":"Real federal consumption expenditures & gross investment",
-#         "realdpi": "Real private disposable income",
-#         "cpi" :"Consumer price index",
-#         "m1": "M1 nominal money stock",
-#         "tbilrate": "3-monthtreasury bill",
-#         "unemp" :"Unemployment rate",
-#         "pop":"Population",
-#         "infl":"Inflation rate (cpi base)",
-#         "realint":"Real interest rate (tbilrate - infl)"
-#         })
-#     df = pd.concat([load_test_data()[1], load_test_data()[0]], axis=1)
-#     st.header("Currency Data (USDJPY and USDEUR) from FRED")
-#     df = get_indices(False)
-#     st.session_state["df"] = df
-# else:
-#     st.session_state["df"] = None
-st.markdown("### data outlook")
-df = load_csv()
 
-if df is not None:
-    st.dataframe(
-        df.style.set_properties(
-            **{"background-color": "yellow"}, subset=df.columns[0]
-        )
-    )
-    st.write("Pairplot first 5 columns")
-    st.pyplot(sns.pairplot(data=df.iloc[:, :5]))
-    st.write("Clustermap of correlation")
-    st.pyplot(
-        sns.clustermap(
-            df.corr().round(2), row_cluster=True, annot=True, center=0, figsize=(6, 6)
-        )
-    )
+st.subheader("ページ一覧")
+page_definitions = get_page_definitions()
+for page in page_definitions:
+    with st.container(border=True):
+        col1, col2 = st.columns([3, 1])
+        with col1:
+            st.markdown(f"### {page.title}")
+            st.write(page.description)
+            st.code(f"pages/{page.file_name}", language="bash")
+        with col2:
+            st.metric("Status", page.status)
+
+st.info("新しい機能ページを追加する場合は `pages/` に新しい `.py` ファイルを作成してください。")

--- a/pages/00_getting_started.py
+++ b/pages/00_getting_started.py
@@ -1,0 +1,16 @@
+import streamlit as st
+
+st.title("はじめに")
+st.write("このページでは、ダッシュボードの基本構成とページ追加手順を説明します。")
+
+st.markdown(
+    """
+## ページ追加の流れ
+1. `pages/` 配下に `NN_feature_name.py` 形式でファイルを作成
+2. UIコードをページファイルに実装
+3. 共通ロジックは `core/` に切り出して再利用
+4. 必要に応じて `core/page_registry.py` に説明を追加
+"""
+)
+
+st.success("このページをベースに、機能ごとのページを増やしてください。")

--- a/pages/10_kpi_dashboard.py
+++ b/pages/10_kpi_dashboard.py
@@ -1,0 +1,11 @@
+import streamlit as st
+
+st.title("KPIダッシュボード")
+st.caption("主要KPIを表示するためのプレースホルダー")
+
+col1, col2, col3 = st.columns(3)
+col1.metric("Daily Active Users", "-", "")
+col2.metric("Revenue", "-", "")
+col3.metric("Conversion Rate", "-", "")
+
+st.info("ここに実データ連携と可視化コンポーネントを追加してください。")

--- a/pages/20_data_explorer.py
+++ b/pages/20_data_explorer.py
@@ -1,0 +1,18 @@
+import pandas as pd
+import streamlit as st
+
+st.title("データ探索")
+st.caption("フィルタ・テーブル表示ページのプレースホルダー")
+
+sample_df = pd.DataFrame(
+    {
+        "category": ["A", "B", "C"],
+        "value": [10, 20, 30],
+    }
+)
+
+selected = st.multiselect("category", options=sample_df["category"].tolist())
+if selected:
+    sample_df = sample_df[sample_df["category"].isin(selected)]
+
+st.dataframe(sample_df, use_container_width=True)

--- a/pages/30_settings.py
+++ b/pages/30_settings.py
@@ -1,0 +1,23 @@
+import configparser
+from pathlib import Path
+
+import streamlit as st
+
+st.title("設定")
+st.caption("config.ini の内容を確認するページ")
+
+config_path = Path("config.ini")
+
+if not config_path.exists():
+    st.error("config.ini が見つかりません。")
+else:
+    parser = configparser.ConfigParser()
+    parser.read(config_path, encoding="utf-8")
+
+    sections = parser.sections()
+    if not sections:
+        st.warning("config.ini にセクションが定義されていません。")
+
+    for section in sections:
+        st.subheader(section)
+        st.json({key: value for key, value in parser.items(section)})


### PR DESCRIPTION
### Motivation
- Provide a clean, extensible Streamlit multipage scaffold so each feature can live in its own `pages/` file while a single top-level index shows an overview. 
- Separate page metadata from UI logic to make it easy to add and register new pages without changing the top page.

### Description
- Reworked the top page into a dashboard index by replacing the previous `index.py` contents with a multipage index that calls `get_page_definitions()` from `core/page_registry.py` and uses `st.set_page_config`, `st.container`, and `st.columns` to render a page list. 
- Added `core/page_registry.py` which defines a frozen `PageDefinition` dataclass and the `get_page_definitions()` function that centralizes page metadata (file name, title, description, status). 
- Added initial placeholder pages under `pages/`: `00_getting_started.py`, `10_kpi_dashboard.py`, `20_data_explorer.py`, and `30_settings.py`, each implemented as a self-contained Streamlit page demonstrating the expected structure and basic UI elements. 
- Removed the previous inline sample-data visualization from the top page so UI now focuses on page discovery and registration via `core/page_registry.py`.

### Testing
- Ran bytecode compilation on the modified files with `python -m py_compile index.py core/page_registry.py pages/00_getting_started.py pages/10_kpi_dashboard.py pages/20_data_explorer.py pages/30_settings.py`, which completed successfully. 
- Attempted to run the app with `streamlit run index.py`, but the `streamlit` CLI is not available in this environment so the run failed. 
- Queried `python -m streamlit --version` to validate installation and it failed because the Streamlit module is not installed in the environment. 
- Tried to capture a screenshot via Playwright at `http://127.0.0.1:8501`, which returned `ERR_EMPTY_RESPONSE` because the Streamlit server was not running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d3612ad20832da1419705fc70d00d)